### PR TITLE
(fix) Handle error when failing to checkout out a SHA

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    terrafile (0.1.2)
+    terrafile (0.1.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/terrafile/dependency.rb
+++ b/lib/terrafile/dependency.rb
@@ -30,6 +30,11 @@ module Terrafile
       Dir.chdir(name) do
         Helper.run!("git checkout #{version} 1> /dev/null")
       end
+    rescue Error => error
+      raise unless error.message.match?(/reference is not a tree/)
+
+      Kernel.puts "[*] WARN: #{error} ." \
+        "The 'version' should be the branch name or tag, rather than the SHA."
     end
   end
 end

--- a/lib/terrafile/installer.rb
+++ b/lib/terrafile/installer.rb
@@ -28,7 +28,7 @@ module Terrafile
       Dir.chdir(Terrafile::MODULES_PATH) do
         dependencies.each do |dependency|
           msg = "Checking out #{dependency.version} from #{dependency.source}"
-          Kernel.puts msg
+          Kernel.puts "[*] #{msg}"
           dependency.fetch
           dependency.checkout
         end

--- a/lib/terrafile/version.rb
+++ b/lib/terrafile/version.rb
@@ -1,3 +1,3 @@
 module Terrafile
-  VERSION = '0.1.2'.freeze
+  VERSION = '0.1.3'.freeze
 end


### PR DESCRIPTION
We believe that a good (simple) convention is for a module's 'version'
always to be a tag or a branch name rather than a particular SHA.

If the attempt to `git checkout` a particular SHA results in a
'fatal: reference is not a tree:' error, we catch that error and print
out a warning.

In the near future we will start re-raising the error to enforce the
use of tag and branch names only.