### PR TITLE
Stop CI running twice on new PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    branches:
+      - master
+  push:
 
 jobs:
   test:


### PR DESCRIPTION
When a new PR is created, we run CI on both push and the PR, so we end up with two runs. This is unnecessary.